### PR TITLE
Improve OpenJDK JVM settings for jenkins master

### DIFF
--- a/apps/jenkins/src/main/fabric8/openshift-deployment.yml
+++ b/apps/jenkins/src/main/fabric8/openshift-deployment.yml
@@ -60,8 +60,12 @@ spec:
           value: "true"
         - name: KUBERNETES_MASTER
           value: "https://kubernetes.default:443"
-        - name: MAX_METASPACE_SIZE
-          value: 200m
+        - name: JAVA_OPTS
+          value: "-XX:+UnlockExperimentalVMOptions -XX:+UseCGroupMemoryLimitForHeap -Dsun.zip.disableMemoryMapping=true"
+        - name: OPENSHIFT_JENKINS_JVM_ARCH
+          value: "i686"
+        - name: CONTAINER_INITIAL_PERCENT
+          value: "0.07"
         - name: JENKINS_OPTS
           value: "-Dgroovy.use.classvalue=true"
         - name: RECOMMENDER_API_TOKEN
@@ -71,7 +75,7 @@ spec:
               key: token
         resources:
             limits:
-              memory: 1Gi
+              memory: 512Mi
               cpu: 2
             requests:
               cpu: "0"

--- a/apps/jenkins/src/main/fabric8/openshift-deployment.yml
+++ b/apps/jenkins/src/main/fabric8/openshift-deployment.yml
@@ -60,12 +60,16 @@ spec:
           value: "true"
         - name: KUBERNETES_MASTER
           value: "https://kubernetes.default:443"
+        - name: JAVA_GC_OPTS
+          value: "-XX:+UseParallelGC -XX:MinHeapFreeRatio=5 -XX:MaxHeapFreeRatio=10 -XX:GCTimeRatio=4 -XX:AdaptiveSizePolicyWeight=90"
         - name: JAVA_OPTS
           value: "-XX:+UnlockExperimentalVMOptions -XX:+UseCGroupMemoryLimitForHeap -Dsun.zip.disableMemoryMapping=true"
         - name: OPENSHIFT_JENKINS_JVM_ARCH
           value: "i686"
         - name: CONTAINER_INITIAL_PERCENT
           value: "0.07"
+        - name: CONTAINTER_INITIAL_PERCENT
+          value: "something-non-empty"
         - name: JENKINS_OPTS
           value: "-Dgroovy.use.classvalue=true"
         - name: RECOMMENDER_API_TOKEN


### PR DESCRIPTION
- Set container limit to 512MB
- Set CONTAINTER_INITIAL_PERCENT to a reasonably
  small value. This will also prevent -Xms == -Xmx
  setting.
- Set OPENSHIFT_JENKINS_JVM_ARCH so 32bit JVM
  will be used.
- Set JAVA_OPTS so as to:
  - Disable memory mapping for JAR files.
  - Use the set container CGroup limit for heap.
- Set JAVA_GC_OPTS so as to use Parallel GC with more aggressive
  metrics so as to actually hand back memory pages and keep the free
  ratio low.