### PR TITLE
lets add a link to the console and keycloak URLs

### DIFF
--- a/apps/jenkins/src/main/fabric8/template.yml
+++ b/apps/jenkins/src/main/fabric8/template.yml
@@ -4,3 +4,4 @@ parameters:
 - name: RECOMMENDER_API_TOKEN
 - name: KEYCLOAK_URL
   value: http://keycloak
+- name: FABRIC8_CONSOLE_URL

--- a/packages/fabric8-tenant-jenkins/src/main/fabric8/fabric8-space-link-cm.yml
+++ b/packages/fabric8-tenant-jenkins/src/main/fabric8/fabric8-space-link-cm.yml
@@ -10,3 +10,9 @@ metadata:
     version: ${project.version}
 data:
   space: ${PROJECT_NAMESPACE}
+
+  # where is the fabric8 console
+  fabric8-console-url: ${FABRIC8_CONSOLE_URL}
+
+  # where is the fabric8 console
+  keycloak-url: ${KEYCLOAK_URL}

--- a/packages/fabric8-tenant-jenkins/src/main/fabric8/template.yml
+++ b/packages/fabric8-tenant-jenkins/src/main/fabric8/template.yml
@@ -7,4 +7,4 @@ parameters:
   value: recommender.api.prod-preview.openshift.io
 - name: RECOMMENDER_API_TOKEN
 - name: KEYCLOAK_URL
-  value: http://keycloak
+- name: FABRIC8_CONSOLE_URL


### PR DESCRIPTION
mostly used for automating the E2E tests in a tenant on fabric8