### PR TITLE
oso monitor proof-of-concept: jenkins content-repository prometheus

### DIFF
--- a/apps/content-repository/src/main/fabric8/cm.yml
+++ b/apps/content-repository/src/main/fabric8/cm.yml
@@ -1,0 +1,2 @@
+data:
+  osio-acl-server: "https://oso-monitor-dsaas-preview.b6ff.rh-idev.openshiftapps.com"

--- a/apps/content-repository/src/main/fabric8/content-repository-deployment.yml
+++ b/apps/content-repository/src/main/fabric8/content-repository-deployment.yml
@@ -42,6 +42,22 @@ spec:
         - mountPath: "/var/www/html"
           name: "content"
           readOnly: false
+      - env:
+        - name: "OSIO_NAMESPACE"
+          valueFrom:
+            fieldRef:
+              fieldPath: "metadata.namespace"
+        - name: "OSIO_ACL_SERVER"
+          valueFrom:
+            configMapKeyRef:
+              key: "osio-acl-server"
+              name: "content-repository"
+        image: "registry.devshift.net/perf/oso-webapi-guard"
+        name: oso-webapi-guard
+        imagePullPolicy: "IfNotPresent"
+        ports:
+          - containerPort: 8001
+            name: "pcp-webguard"
       volumes:
       - name: content
         persistentVolumeClaim:

--- a/apps/content-repository/src/main/fabric8/pcp-route.yml
+++ b/apps/content-repository/src/main/fabric8/pcp-route.yml
@@ -1,0 +1,9 @@
+metadata:
+  name: "pcp"
+spec:
+  to:
+    kind: Service
+    name: "pcp"
+  tls:
+    termination: edge
+    insecureEdgeTerminationPolicy: Redirect

--- a/apps/content-repository/src/main/fabric8/pcp-svc.yml
+++ b/apps/content-repository/src/main/fabric8/pcp-svc.yml
@@ -1,0 +1,17 @@
+apiVersion: "v1"
+kind: "Service"
+metadata:
+  labels:
+    app: "${project.artifactId}-pcp"
+    expose: "false"
+  name: "pcp"
+spec:
+  ports:
+  - name: "http"
+    protocol: "TCP"
+    port: 80
+    targetPort: 8001
+  selector:
+    app: "content-repository"
+    provider: "fabric8"
+    


### PR DESCRIPTION
Add a httpd relay to securely export the content-repository prometheus
stats to OSIO metrics collectors running in OSD.  For now, the URL to
fetch authentication information is hard-coded as a
.rh-idev.openshiftapps.com URL, but soon will become a
prod-preview.openshift.io type URL.  The web server is designed to be
unreachable except from the OSIO peer, and cost only a few MB of RAM.

While the code in this PR does work and should be harmless if deployed,
this PR is an opening move for discussion rather than a representation of
a finished product.  Feedback very welcome!