### PR TITLE
fix for Jenkins log URL

### DIFF
--- a/apps/jenkins/ReadMe.md
+++ b/apps/jenkins/ReadMe.md
@@ -1,3 +1,8 @@
 Jenkins CI is a leading open-source continuous integration server. Built with Java, it provides 985 plugins to support building and testing virtually any project.
 
+
+Configurations:
+--------------------------------------
+ - `JENKINS_ROOT_URL` : By default, the Jenkins base URL for the build log is determined via the OpenShift route of the Jenkins service. To override and configure this base URL, an environment variable `JENKINS_ROOT_URL` can be set through [openshift deployment-config yaml](https://github.com/fabric8-services/fabric8-tenant-jenkins/blob/master/apps/jenkins/src/main/fabric8/openshift-deployment.yml)
+
 [http://jenkins-ci.org/](http://jenkins-ci.org/)

--- a/apps/jenkins/src/main/fabric8/openshift-deployment.yml
+++ b/apps/jenkins/src/main/fabric8/openshift-deployment.yml
@@ -76,6 +76,8 @@ spec:
             secretKeyRef:
               name: jenkins-recommender-api-token
               key: token
+        - name: JENKINS_ROOT_URL
+          value: "${JENKINS_ROOT_URL}"
         resources:
             limits:
               memory: 512Mi

--- a/packages/fabric8-tenant-jenkins/src/main/fabric8/template.yml
+++ b/packages/fabric8-tenant-jenkins/src/main/fabric8/template.yml
@@ -8,3 +8,4 @@ parameters:
 - name: RECOMMENDER_API_TOKEN
 - name: KEYCLOAK_URL
 - name: FABRIC8_CONSOLE_URL
+- name: JENKINS_ROOT_URL


### PR DESCRIPTION
- added a new ENV var JENKINS_ROOT_URL to openshift-deployment.yml
fix for #64 