### PR TITLE
changing the caddy version to the latest version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -81,9 +81,9 @@
      to download their docker images!
      -->
     <fabric8.openshift.deployTimeoutSeconds>10000</fabric8.openshift.deployTimeoutSeconds>
-    
+
     <arquillian.version>1.1.8.Final</arquillian.version>
-    <caddy-server.version>v9274a15</caddy-server.version>
+    <caddy-server.version>v6b386d6</caddy-server.version>
     <fabric8.version>2.2.205</fabric8.version>
     <fabric8-devops.version>2.2.335</fabric8-devops.version>
     <fabric8.maven.plugin.version>3.5.37</fabric8.maven.plugin.version>


### PR DESCRIPTION
Updating the caddy server version, which includes fixes regarding license in https://registry.centos.org/repo/caddyserver/caddyserver,
Ref: HK1340