### PR TITLE
Add ObjectMeta.getLabels to whitelist

### DIFF
--- a/apps/jenkins-test/src/main/fabric8/kubernetes-cm.yml
+++ b/apps/jenkins-test/src/main/fabric8/kubernetes-cm.yml
@@ -95,6 +95,7 @@ data:
         <string>method io.fabric8.kubernetes.api.model.Doneable done</string>
         <string>method io.fabric8.kubernetes.api.model.KubernetesResourceList getItems</string>
         <string>method io.fabric8.kubernetes.api.model.ObjectMeta getName</string>
+        <string>method io.fabric8.kubernetes.api.model.ObjectMeta getLabels</string>
         <string>method io.fabric8.kubernetes.api.model.ObjectMetaFluent addToAnnotations java.lang.String java.lang.String</string>
         <string>method io.fabric8.kubernetes.api.model.ObjectMetaFluent withName java.lang.String</string>
         <string>method io.fabric8.kubernetes.api.pipelines.PipelineConfiguration getUseDockerSocketFlag</string>

--- a/apps/jenkins-test/src/main/fabric8/openshift-cm.yml
+++ b/apps/jenkins-test/src/main/fabric8/openshift-cm.yml
@@ -98,6 +98,7 @@ data:
         <string>method io.fabric8.kubernetes.api.model.Doneable done</string>
         <string>method io.fabric8.kubernetes.api.model.KubernetesResourceList getItems</string>
         <string>method io.fabric8.kubernetes.api.model.ObjectMeta getName</string>
+        <string>method io.fabric8.kubernetes.api.model.ObjectMeta getLabels</string>
         <string>method io.fabric8.kubernetes.api.model.ObjectMetaFluent addToAnnotations java.lang.String java.lang.String</string>
         <string>method io.fabric8.kubernetes.api.model.ObjectMetaFluent withName java.lang.String</string>
         <string>method io.fabric8.kubernetes.api.pipelines.PipelineConfiguration getUseDockerSocketFlag</string>

--- a/apps/jenkins/src/main/fabric8/kubernetes-cm.yml
+++ b/apps/jenkins/src/main/fabric8/kubernetes-cm.yml
@@ -95,6 +95,7 @@ data:
         <string>method io.fabric8.kubernetes.api.model.Doneable done</string>
         <string>method io.fabric8.kubernetes.api.model.KubernetesResourceList getItems</string>
         <string>method io.fabric8.kubernetes.api.model.ObjectMeta getName</string>
+        <string>method io.fabric8.kubernetes.api.model.ObjectMeta getLabels</string>
         <string>method io.fabric8.kubernetes.api.model.ObjectMetaFluent addToAnnotations java.lang.String java.lang.String</string>
         <string>method io.fabric8.kubernetes.api.model.ObjectMetaFluent withName java.lang.String</string>
         <string>method io.fabric8.kubernetes.api.pipelines.PipelineConfiguration getUseDockerSocketFlag</string>

--- a/apps/jenkins/src/main/fabric8/openshift-cm.yml
+++ b/apps/jenkins/src/main/fabric8/openshift-cm.yml
@@ -98,6 +98,7 @@ data:
         <string>method io.fabric8.kubernetes.api.model.Doneable done</string>
         <string>method io.fabric8.kubernetes.api.model.KubernetesResourceList getItems</string>
         <string>method io.fabric8.kubernetes.api.model.ObjectMeta getName</string>
+        <string>method io.fabric8.kubernetes.api.model.ObjectMeta getLabels</string>
         <string>method io.fabric8.kubernetes.api.model.ObjectMetaFluent addToAnnotations java.lang.String java.lang.String</string>
         <string>method io.fabric8.kubernetes.api.model.ObjectMetaFluent withName java.lang.String</string>
         <string>method io.fabric8.kubernetes.api.pipelines.PipelineConfiguration getUseDockerSocketFlag</string>


### PR DESCRIPTION
This PR adds `io.fabric8.kubernetes.api.model.ObjectMeta getLabels` to the whitelist used by Jenkins. This method is necessary for https://github.com/fabric8io/fabric8-pipeline-library/pull/390, which allows us to read the `space` label from the currently running OpenShift Build object.