### PR TITLE
Remove groovy wrappers around git to fix the CD pipeline

### DIFF
--- a/release.groovy
+++ b/release.groovy
@@ -50,15 +50,18 @@ def updatefabric8Tenant(releaseVersion){
       def flow = new io.fabric8.Fabric8Commands()
       flow.setupGitSSH()
 
-      git 'git@github.com:fabric8-services/fabric8-tenant.git'
-
       def uid = UUID.randomUUID().toString()
-      sh "git checkout -b versionUpdate${uid}"
-
-      sh "echo ${releaseVersion} > JENKINS_VERSION"
+      def branch = "versionUpdate${uid}"
       def message = "Update fabric8-tenant-jenkins version to ${releaseVersion}"
-      sh "git commit -a -m \"${message}\""
-      sh "git push origin versionUpdate${uid}"
+
+      sh """
+         git clone git@github.com:fabric8-services/fabric8-tenant.git --depth 1
+         cd fabric8-tenant
+         echo ${releaseVersion} > JENKINS_VERSION
+         git checkout -b ${branch}
+         git commit -a -m "${message}"
+         git push origin ${branch}
+         """
 
       def prId = flow.createPullRequest(message,'fabric8-services/fabric8-tenant',"versionUpdate${uid}")
       flow.mergePR('fabric8-services/fabric8-tenant',prId)


### PR DESCRIPTION
Fixes https://github.com/openshiftio/openshift.io/issues/3353

Fixes the stack trace at https://jenkins.cd.test.fabric8.io/job/fabric8-services/job/fabric8-tenant-jenkins/job/master/62

```
ERROR: Error cloning remote repo 'origin'
hudson.plugins.git.GitException: Command "git fetch --tags --progress git@github.com:fabric8-services/fabric8-tenant.git +refs/heads/*:refs/remotes/origin/*" returned status code 128:
stdout:
stderr: Host key verification failed.
fatal: Could not read from remote repository.

Please make sure you have the correct access rights
and the repository exists.

    at org.jenkinsci.plugins.gitclient.CliGitAPIImpl.launchCommandIn(CliGitAPIImpl.java:1924)
    at org.jenkinsci.plugins.gitclient.CliGitAPIImpl.launchCommandWithCredentials(CliGitAPIImpl.java:1643)
    at org.jenkinsci.plugins.gitclient.CliGitAPIImpl.access$300(CliGitAPIImpl.java:71)
    at org.jenkinsci.plugins.gitclient.CliGitAPIImpl$1.execute(CliGitAPIImpl.java:352)
    at org.jenkinsci.plugins.gitclient.CliGitAPIImpl$2.execute(CliGitAPIImpl.java:559)
    at org.jenkinsci.plugins.gitclient.RemoteGitImpl$CommandInvocationHandler$1.call(RemoteGitImpl.java:153)
    at org.jenkinsci.plugins.gitclient.RemoteGitImpl$CommandInvocationHandler$1.call(RemoteGitImpl.java:146)
    at hudson.remoting.UserRequest.perform(UserRequest.java:121)
    at hudson.remoting.UserRequest.perform(UserRequest.java:49)
    at hudson.remoting.Request$2.run(Request.java:326)
    at hudson.remoting.InterceptingExecutorService$1.call(InterceptingExecutorService.java:68)
    at java.util.concurrent.FutureTask.run(FutureTask.java:266)
    at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1142)
    at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:617)
    at hudson.remoting.Engine$1$1.run(Engine.java:69)
    at java.lang.Thread.run(Thread.java:745)
    Suppressed: hudson.remoting.Channel$CallSiteStackTrace: Remote call to Channel to /10.12.12.15
        at hudson.remoting.Channel.attachCallSiteStackTrace(Channel.java:1693)
        at hudson.remoting.UserResponse.retrieve(UserRequest.java:310)
        at hudson.remoting.Channel.call(Channel.java:908)
        at org.jenkinsci.plugins.gitclient.RemoteGitImpl$CommandInvocationHandler.execute(RemoteGitImpl.java:146)
        at sun.reflect.GeneratedMethodAccessor556.invoke(Unknown Source)
        at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
        at java.lang.reflect.Method.invoke(Method.java:498)
        at org.jenkinsci.plugins.gitclient.RemoteGitImpl$CommandInvocationHandler.invoke(RemoteGitImpl.java:132)
        at com.sun.proxy.$Proxy134.execute(Unknown Source)
        at hudson.plugins.git.GitSCM.retrieveChanges(GitSCM.java:1075)
        at hudson.plugins.git.GitSCM.checkout(GitSCM.java:1115)
        at org.jenkinsci.plugins.workflow.steps.scm.SCMStep.checkout(SCMStep.java:113)
        at org.jenkinsci.plugins.workflow.steps.scm.SCMStep$StepExecutionImpl.run(SCMStep.java:85)
        at org.jenkinsci.plugins.workflow.steps.scm.SCMStep$StepExecutionImpl.run(SCMStep.java:75)
        at org.jenkinsci.plugins.workflow.steps.AbstractSynchronousNonBlockingStepExecution$1$1.call(AbstractSynchronousNonBlockingStepExecution.java:47)
        at hudson.security.ACL.impersonate(ACL.java:260)
        at org.jenkinsci.plugins.workflow.steps.AbstractSynchronousNonBlockingStepExecution$1.run(AbstractSynchronousNonBlockingStepExecution.java:44)
        at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511)
        at java.util.concurrent.FutureTask.run(FutureTask.java:266)
        at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
        at java.lang.Thread.run(Thread.java:748)
```