### PR TITLE
Add content-repository boot dependency to Jenkins

### DIFF
--- a/apps/jenkins-test/src/main/fabric8/kubernetes-jenkins-deployment.yml
+++ b/apps/jenkins-test/src/main/fabric8/kubernetes-jenkins-deployment.yml
@@ -10,6 +10,10 @@ spec:
   replicas: 1
   template:
     spec:
+      initContainers:
+      - name: "content-repository-init"
+        image: "centos:7"
+        command: ['sh', '-c', 'for i in {1..100}; do sleep 1; if curl -L -m 4 content-repository; then exit 0; else echo waiting for content-repository ...; fi; done; exit 1']
       containers:
       - image: "fabric8/jenkins-openshift:${jenkins-openshift.version}"
         imagePullPolicy: "IfNotPresent"

--- a/apps/jenkins-test/src/main/fabric8/openshift-deployment.yml
+++ b/apps/jenkins-test/src/main/fabric8/openshift-deployment.yml
@@ -14,6 +14,10 @@ spec:
       timeoutSeconds: 7200
   template:
     spec:
+      initContainers:
+      - name: "content-repository-init"
+        image: "centos:7"
+        command: ['sh', '-c', 'for i in {1..100}; do sleep 1; if curl -L -m 4 content-repository; then exit 0; else echo waiting for content-repository ...; fi; done; exit 1']
       containers:
       - image: "fabric8/jenkins-openshift:${jenkins-openshift.version}"
         imagePullPolicy: "IfNotPresent"

--- a/apps/jenkins/src/main/fabric8/kubernetes-jenkins-deployment.yml
+++ b/apps/jenkins/src/main/fabric8/kubernetes-jenkins-deployment.yml
@@ -10,6 +10,10 @@ spec:
   replicas: 1
   template:
     spec:
+      initContainers:
+      - name: "content-repository-init"
+        image: "centos:7"
+        command: ['sh', '-c', 'for i in {1..100}; do sleep 1; if curl -L -m 4 content-repository; then exit 0; else echo waiting for content-repository ...; fi; done; exit 1']
       containers:
       - image: "fabric8/jenkins-openshift:${jenkins-openshift.version}"
         imagePullPolicy: "IfNotPresent"

--- a/apps/jenkins/src/main/fabric8/openshift-deployment.yml
+++ b/apps/jenkins/src/main/fabric8/openshift-deployment.yml
@@ -14,6 +14,10 @@ spec:
       timeoutSeconds: 7200
   template:
     spec:
+      initContainers:
+      - name: "content-repository-init"
+        image: "centos:7"
+        command: ['sh', '-c', 'for i in {1..100}; do sleep 1; if curl -L -m 4 content-repository; then exit 0; else echo waiting for content-repository ...; fi; done; exit 1']
       containers:
       - image: "fabric8/jenkins-openshift:${jenkins-openshift.version}"
         imagePullPolicy: "IfNotPresent"


### PR DESCRIPTION
This commit adds a hard dependency on the Jenkins deployment such
that Jenkins will not be brought up unless content-repository is
not up and running.

This is done by adding init containers to the Jenkins' Kubernetes
Deployment files which check every 2 seconds if content-repository
is up or not. The check is set to timeout at 2 seconds. Once the
check returns a 0 exit code and the init container exits, only
then the Jenkins pod is brought up.