### PR TITLE
Lower retry count in Jenkins init containers

### DIFF
--- a/apps/jenkins-test/src/main/fabric8/kubernetes-jenkins-deployment.yml
+++ b/apps/jenkins-test/src/main/fabric8/kubernetes-jenkins-deployment.yml
@@ -13,7 +13,7 @@ spec:
       initContainers:
       - name: "content-repository-init"
         image: "centos:7"
-        command: ['sh', '-c', 'for i in {1..100}; do sleep 1; if curl -L -m 4 content-repository; then exit 0; else echo waiting for content-repository ...; fi; done; exit 1']
+        command: ['sh', '-c', 'for i in {1..10}; do sleep 1; if curl -L -m 4 content-repository; then exit 0; else echo waiting for content-repository ...; fi; done; exit 1']
       containers:
       - image: "fabric8/jenkins-openshift:${jenkins-openshift.version}"
         imagePullPolicy: "IfNotPresent"

--- a/apps/jenkins-test/src/main/fabric8/openshift-deployment.yml
+++ b/apps/jenkins-test/src/main/fabric8/openshift-deployment.yml
@@ -17,7 +17,7 @@ spec:
       initContainers:
       - name: "content-repository-init"
         image: "centos:7"
-        command: ['sh', '-c', 'for i in {1..100}; do sleep 1; if curl -L -m 4 content-repository; then exit 0; else echo waiting for content-repository ...; fi; done; exit 1']
+        command: ['sh', '-c', 'for i in {1..10}; do sleep 1; if curl -L -m 4 content-repository; then exit 0; else echo waiting for content-repository ...; fi; done; exit 1']
       containers:
       - image: "fabric8/jenkins-openshift:${jenkins-openshift.version}"
         imagePullPolicy: "IfNotPresent"

--- a/apps/jenkins/src/main/fabric8/kubernetes-jenkins-deployment.yml
+++ b/apps/jenkins/src/main/fabric8/kubernetes-jenkins-deployment.yml
@@ -13,7 +13,7 @@ spec:
       initContainers:
       - name: "content-repository-init"
         image: "centos:7"
-        command: ['sh', '-c', 'for i in {1..100}; do sleep 1; if curl -L -m 4 content-repository; then exit 0; else echo waiting for content-repository ...; fi; done; exit 1']
+        command: ['sh', '-c', 'for i in {1..10}; do sleep 1; if curl -L -m 4 content-repository; then exit 0; else echo waiting for content-repository ...; fi; done; exit 1']
       containers:
       - image: "fabric8/jenkins-openshift:${jenkins-openshift.version}"
         imagePullPolicy: "IfNotPresent"

--- a/apps/jenkins/src/main/fabric8/openshift-deployment.yml
+++ b/apps/jenkins/src/main/fabric8/openshift-deployment.yml
@@ -17,7 +17,7 @@ spec:
       initContainers:
       - name: "content-repository-init"
         image: "centos:7"
-        command: ['sh', '-c', 'for i in {1..100}; do sleep 1; if curl -L -m 4 content-repository; then exit 0; else echo waiting for content-repository ...; fi; done; exit 1']
+        command: ['sh', '-c', 'for i in {1..10}; do sleep 1; if curl -L -m 4 content-repository; then exit 0; else echo waiting for content-repository ...; fi; done; exit 1']
       containers:
       - image: "fabric8/jenkins-openshift:${jenkins-openshift.version}"
         imagePullPolicy: "IfNotPresent"


### PR DESCRIPTION
This commit lowers the retry count in Jenkins init containers from
100 to 10. This is done because due to an underlying OpenShift
networking issue at
https://github.com/openshiftio/openshift.io/issues/3299, the init
container is not always able to talk to the content-repository
reliably leading to failure in bringing up Jenkins. With a low
retry count i.e. 10, the init container will fail fast if this
intermittent network failure occurs, and another pod will be
started by OpenShift which should be able to talk to
content-repository, hopefully!