### PR TITLE
 Fix build not getting cancelled on update in PR

### DIFF
--- a/apps/jenkins/src/main/fabric8/openshift-cm.yml
+++ b/apps/jenkins/src/main/fabric8/openshift-cm.yml
@@ -347,5 +347,33 @@ data:
         <scanQueueFor>DISABLED</scanQueueFor>
         <blockingJobs>.*</blockingJobs>
     </hudson.plugins.buildblocker.BuildBlockerProperty_-DescriptorImpl>
+  org.jenkinsci.plugins.ghprb.GhprbTrigger.xml: |-
+    <?xml version='1.0' encoding='UTF-8'?>
+    <org.jenkinsci.plugins.ghprb.GhprbTrigger_-DescriptorImpl plugin="ghprb@1.42.0">
+      <configVersion>1</configVersion>
+      <whitelistPhrase>.*add\W+to\W+whitelist.*</whitelistPhrase>
+      <okToTestPhrase>.*ok\W+to\W+test.*</okToTestPhrase>
+      <retestPhrase>.*test\W+this\W+please.*</retestPhrase>
+      <skipBuildPhrase>.*\[skip\W+ci\].*</skipBuildPhrase>
+      <blackListCommitAuthor></blackListCommitAuthor>
+      <cron>H/5 * * * *</cron>
+      <useComments>false</useComments>
+      <useDetailedComments>false</useDetailedComments>
+      <manageWebhooks>true</manageWebhooks>
+      <unstableAs>FAILURE</unstableAs>
+      <autoCloseFailedPullRequests>false</autoCloseFailedPullRequests>
+      <displayBuildErrorsOnDownstreamBuilds>false</displayBuildErrorsOnDownstreamBuilds>
+      <extensions>
+        <org.jenkinsci.plugins.ghprb.extensions.status.GhprbSimpleStatus>
+          <commitStatusContext></commitStatusContext>
+          <showMatrixStatus>false</showMatrixStatus>
+          <addTestResults>false</addTestResults>
+          <completedStatus/>
+        </org.jenkinsci.plugins.ghprb.extensions.status.GhprbSimpleStatus>
+        <org.jenkinsci.plugins.ghprb.extensions.build.GhprbCancelBuildsOnUpdate>
+          <overrideGlobal>false</overrideGlobal>
+        </org.jenkinsci.plugins.ghprb.extensions.build.GhprbCancelBuildsOnUpdate>
+      </extensions>
+    </org.jenkinsci.plugins.ghprb.GhprbTrigger_-DescriptorImpl>
 
 


### PR DESCRIPTION
Fixes openshiftio/openshift.io#3862

So when you push to a PR, the previous build keeps going on, but it should
cancel and build for new commit should start. This change is to fix that

Regarding the file, this is autogenerated in var/lib/jenkins by the
name of org.jenkinsci.plugins.ghprb.GhprbTrigger.xml

I am overriding that file by mentioning it in configmap with the key file
name. I am using the whole content of that file an adding one more
extension of CancelBuildOnUpdate

```
<org.jenkinsci.plugins.ghprb.extensions.build.GhprbCancelBuildsOnUpdate>
      <overrideGlobal>false</overrideGlobal>
</org.jenkinsci.plugins.ghprb.extensions.build.GhprbCancelBuildsOnUpdate>
```

Information regarding this configuration can be found here https://github.com/jenkinsci/ghprb-plugin/blob/master/src/main/java/org/jenkinsci/plugins/ghprb/extensions/build/GhprbCancelBuildsOnUpdate.java