### PR TITLE
Fixes build starts with Maven artifactIds fails

### DIFF
--- a/apps/jenkins/src/main/fabric8/kubernetes-jenkins-deployment.yml
+++ b/apps/jenkins/src/main/fabric8/kubernetes-jenkins-deployment.yml
@@ -70,6 +70,8 @@ spec:
             secretKeyRef:
               name: jenkins-recommender-api-token
               key: token
+        - name: K8S_PIPELINE_SERVICE_PATCH
+          value: enabled
         resources:
             limits:
               memory: 1Gi

--- a/apps/jenkins/src/main/fabric8/openshift-deployment.yml
+++ b/apps/jenkins/src/main/fabric8/openshift-deployment.yml
@@ -82,6 +82,8 @@ spec:
               key: token
         - name: JENKINS_ROOT_URL
           value: "${JENKINS_ROOT_URL}"
+        - name: K8S_PIPELINE_SERVICE_PATCH
+          value: enabled
         resources:
             limits:
               memory: 512Mi


### PR DESCRIPTION
Updated OpenShift and k8s deployment to add ENV var for Kubernetes pipeline Jenkins plugin.

Fixes https://github.com/openshiftio/openshift.io/issues/3784