### PR TITLE
Optimize Jenkins performance to fix slow booting

### DIFF
--- a/apps/jenkins-test/src/main/fabric8/openshift-deployment.yml
+++ b/apps/jenkins-test/src/main/fabric8/openshift-deployment.yml
@@ -60,9 +60,9 @@ spec:
         - name: OPENSHIFT_JENKINS_JVM_ARCH
           value: "i686"
         - name: CONTAINER_INITIAL_PERCENT
-          value: "0.07"
-        - name: CONTAINTER_INITIAL_PERCENT
-          value: "something-non-empty"
+          value: "0.50"
+        - name: CONTAINER_CORE_LIMIT
+          value: "1"
         - name: JENKINS_OPTS
           value: "-Dgroovy.use.classvalue=true"
         - name: JAVA_HOME

--- a/apps/jenkins/src/main/fabric8/openshift-deployment.yml
+++ b/apps/jenkins/src/main/fabric8/openshift-deployment.yml
@@ -61,10 +61,10 @@ spec:
           value: "-XX:+UnlockExperimentalVMOptions -XX:+UseCGroupMemoryLimitForHeap -Dsun.zip.disableMemoryMapping=true"
         - name: OPENSHIFT_JENKINS_JVM_ARCH
           value: "i686"
+        - name: CONTAINER_CORE_LIMIT
+          value: "1"
         - name: CONTAINER_INITIAL_PERCENT
-          value: "0.07"
-        - name: CONTAINTER_INITIAL_PERCENT
-          value: "something-non-empty"
+          value: "0.50"
         - name: JENKINS_OPTS
           value: "-Dgroovy.use.classvalue=true"
         - name: JAVA_HOME


### PR DESCRIPTION
Jenkins works very slow during first boot and unidling phase. It turns
out that JVM Garbage Collector (GC) threads occupies most of CPU aggressively
to avail more heap memory because initial heap size is very less. Hence this
long pause of GC freeze the Jenkins application to execute.
This patch tweaks few JVM GC parameters to set enough heap memory (Xms) that
preventing GC to kick in on Jenkins boot. Also reduces the number of GC threads to
prevent it from using all processor cores.

Fixes https://github.com/openshiftio/openshift.io/issues/3956

Related https://github.com/openshiftio/openshift.io/issues/3861

Thanks! @sthaha 0/