### PR TITLE
Configuration for allowing cancel build on update

### DIFF
--- a/apps/jenkins/src/main/fabric8/kubernetes-cm.yml
+++ b/apps/jenkins/src/main/fabric8/kubernetes-cm.yml
@@ -55,6 +55,7 @@ data:
       <enabled>true</enabled>
       <jobNamePattern>.*</jobNamePattern>
       <namespace>${PROJECT_NAMESPACE}</namespace>
+      <cancelPRBuildOnUpdate>true</cancelPRBuildOnUpdate>
     </io.fabric8.jenkins.openshiftsync.GlobalPluginConfiguration>
   org.jenkinsci.main.modules.sshd.SSHD.xml: |-
     <?xml version='1.0' encoding='UTF-8'?>

--- a/apps/jenkins/src/main/fabric8/openshift-cm.yml
+++ b/apps/jenkins/src/main/fabric8/openshift-cm.yml
@@ -60,6 +60,7 @@ data:
       <enabled>true</enabled>
       <jobNamePattern>.*</jobNamePattern>
       <namespace>${PROJECT_NAMESPACE}</namespace>
+      <cancelPRBuildOnUpdate>true</cancelPRBuildOnUpdate>
     </io.fabric8.jenkins.openshiftsync.GlobalPluginConfiguration>
   org.jenkinsci.main.modules.sshd.SSHD.xml: |-
     <?xml version='1.0' encoding='UTF-8'?>


### PR DESCRIPTION
This will add the flag `cancelPRBuildOnUpdate` in configmap
which will be used by jenkins-sync-plugin to cancel build on
updation in PR.
By default, value is true which will cancel build on update
You can make it false to build all PR commits.

Fix
OSIO Issue openshiftio/openshift.io#3862
Sync Plugin Issue fabric8io/jenkins-sync-plugin#38
Sync Plugin PR fabric8io/jenkins-sync-plugin#40
Openshift-Jenkins-S2I-config PR fabric8io/openshift-jenkins-s2i-config#184
6016c8d