### PR TITLE
Fix 503 errors events of failing readiness probe in Jenkins Pod

### DIFF
--- a/apps/jenkins/src/main/fabric8/kubernetes-jenkins-deployment.yml
+++ b/apps/jenkins/src/main/fabric8/kubernetes-jenkins-deployment.yml
@@ -15,8 +15,9 @@ spec:
         imagePullPolicy: "IfNotPresent"
         name: "jenkins"
         readinessProbe:
-          timeoutSeconds: 10
-          initialDelaySeconds: 10
+          timeoutSeconds: 240
+          initialDelaySeconds: 40
+          periodSeconds: 15
           httpGet:
             path: "/login"
             port: 8080

--- a/apps/jenkins/src/main/fabric8/openshift-deployment.yml
+++ b/apps/jenkins/src/main/fabric8/openshift-deployment.yml
@@ -19,8 +19,9 @@ spec:
         imagePullPolicy: "IfNotPresent"
         name: "jenkins"
         readinessProbe:
-          timeoutSeconds: 10
-          initialDelaySeconds: 10
+          timeoutSeconds: 240
+          initialDelaySeconds: 40
+          periodSeconds: 15
           httpGet:
             path: "/login"
             port: 8080


### PR DESCRIPTION
This will fix the issue of 503 events on Jenkins pod
because of readiness probe failure during the idling/unidling condition
and fewer error events logs for setup

In this commit, basically, the initial delay time has been increased
from 10 seconds to 40 seconds because what we have observed till now is
Jenkins takes approx 3m30s in first startup and approx 30s-35s in subsequent
startups.

Timeout seconds have been increased to 4m because handling the
the scenario where the first startup take approx 3m30s

Period seconds have been increased to 15s to give fewer errors but
access to Jenkins should be given as early as possible

Fixes openshiftio/openshift.io#3934