### PR TITLE
Deprecate this project

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,11 @@
+# WARNING: This project has been deprecated
+
+The template management has been moved directly to [fabric8-tenant](https://github.com/fabric8-services/fabric8-tenant) repository. Any additional changes in the templates should be done in the repo and not here.
+Files that were originally managed/produced by this repo can be found here:
+
+* [fabric8-tenant-jenkins.yml](https://github.com/fabric8-services/fabric8-tenant/blob/master/environment/templates/fabric8-tenant-jenkins.yml)
+* [fabric8-tenant-jenkins-quotas.yml](https://github.com/fabric8-services/fabric8-tenant/blob/master/environment/templates/fabric8-tenant-jenkins-quotas.yml)
+
 # fabric8-tenant-jenkins [![Build Status](https://jenkins.cd.test.fabric8.io/buildStatus/icon?job=fabric8-services/fabric8-tenant-jenkins/master)](https://jenkins.cd.test.fabric8.io/job/fabric8-services/job/fabric8-tenant-jenkins/job/master/)
 
 


### PR DESCRIPTION
This PR adds a README info about the project deprecation ([PR](https://github.com/fabric8-services/fabric8-tenant/pull/634) that moves templates to [fabric8-tenant](https://github.com/fabric8-services/fabric8-tenant/) repo has been merged)
